### PR TITLE
Changes the burndown chart to show the state of the config options

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,8 @@
   }
 </style>
 <body>
-  <h1>Nova API Ref Sprint Burndown</h1>
+  <h1>Nova Config Options Doc Sprint Burndown</h1>
+  <p>see <a href="https://wiki.openstack.org/wiki/ConfigOptionsConsistency">OpenStack wiki</a> for details</p>
 <script src="http://d3js.org/d3.v3.js"></script>
 <script language="javascript">
   var margin = {top: 20, right: 40, bottom: 30, left: 50},
@@ -154,8 +155,9 @@
           return table;
 	}
       // render the table(s)
-      tabulate(data, ['filename', 'needs:method_verification', 'needs:parameter_verification',
-                      'needs:example_verification', 'needs:body_verification']);
+      tabulate(data, ['filename', 'needs:fix_opt_description', 'needs:check_deprecation_status',
+                      'needs:check_opt_group_and_type', 'needs:fix_opt_description_indentation',
+                      'needs:fix_opt_registration_consistency']);
   });
 </script>
 

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,12 @@
 set -e
 
 cd $(dirname $0)
+if [ ! -d "nova" ]; then
+  git clone "https://github.com/openstack/nova.git"
+fi
 pushd nova > /dev/null
 git pull 2>&1 > /dev/null
 popd > /dev/null
 ./api-ref-burndown.py
-git ci -m "Updated csv" > /dev/null
+# Error message `git: 'ci' is not a git command.`. Maybe an alias?
+# git ci -m "Updated csv" > /dev/null


### PR DESCRIPTION
That's the code we currently use to display the burndown chart for the config options cleanup at http://45.55.105.55:8082/config-options.html
It's based on the wiki page https://wiki.openstack.org/wiki/ConfigOptionsConsistency

It is _not_ generically usable right now. When we talked about this some months ago you said you'd like to make the more generic after you have these changes.
